### PR TITLE
Pass ethers provider to UniswapV2 and Kyber quote fetchers

### DIFF
--- a/index-rebalances/utils/paramDetermination/kyberDMM.ts
+++ b/index-rebalances/utils/paramDetermination/kyberDMM.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "ethers";
+import { BaseProvider } from "@ethersproject/providers";
 
 import {
   ChainId,
@@ -27,16 +28,17 @@ const {
 const KYBER_FACTORY = "0x833e4083B7ae46CeA85695c4f7ed25CDAd8886dE";
 
 export async function getKyberDMMQuote(
+  provider: BaseProvider,
   tokenAddress: Address,
   targetPriceImpact: BigNumber
 ): Promise<ExchangeQuote> {
-  const token: kyberToken = await kyberFetcher.fetchTokenData(ChainId.MAINNET, tokenAddress);
-  const weth: kyberToken = await kyberFetcher.fetchTokenData(ChainId.MAINNET, ETH_ADDRESS);
-  const wbtc: kyberToken = await kyberFetcher.fetchTokenData(ChainId.MAINNET, BTC_ADDRESS);
-  const usdc: kyberToken = await kyberFetcher.fetchTokenData(ChainId.MAINNET, USDC_ADDRESS);
+  const token: kyberToken = await kyberFetcher.fetchTokenData(ChainId.MAINNET, tokenAddress, provider);
+  const weth: kyberToken = await kyberFetcher.fetchTokenData(ChainId.MAINNET, ETH_ADDRESS, provider);
+  const wbtc: kyberToken = await kyberFetcher.fetchTokenData(ChainId.MAINNET, BTC_ADDRESS, provider);
+  const usdc: kyberToken = await kyberFetcher.fetchTokenData(ChainId.MAINNET, USDC_ADDRESS, provider);
 
   const trades = await kyberTrade.bestTradeExactIn(
-    await getKyberDMMPairs([token, weth, wbtc, usdc]),
+    await getKyberDMMPairs(provider, [token, weth, wbtc, usdc]),
     new kyberTokenAmount(weth, ether(1).toString()),
     token,
     {maxNumResults: 3, maxHops: 1},
@@ -68,7 +70,7 @@ export async function getKyberDMMQuote(
   } as ExchangeQuote;
 }
 
-async function getKyberDMMPairs(tokens: kyberToken[]): Promise<kyberPair[][]> {
+async function getKyberDMMPairs(provider: BaseProvider, tokens: kyberToken[]): Promise<kyberPair[][]> {
   const pairs: kyberPair[][] = [];
   for (let i = 0; i < tokens.length - 1; i++) {
     for (let j = 1; j < tokens.length - i - 1; j++) {
@@ -77,7 +79,7 @@ async function getKyberDMMPairs(tokens: kyberToken[]): Promise<kyberPair[][]> {
 
       let assetPairs;
       try {
-        assetPairs = await kyberFetcher.fetchPairData(tokenOne, tokenTwo, KYBER_FACTORY);
+        assetPairs = await kyberFetcher.fetchPairData(tokenOne, tokenTwo, KYBER_FACTORY, provider);
       } catch (error) {
         continue;
       }

--- a/index-rebalances/utils/paramDetermination/uniswapV2.ts
+++ b/index-rebalances/utils/paramDetermination/uniswapV2.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "ethers";
+import { BaseProvider } from "@ethersproject/providers";
 import { ether, preciseDiv, preciseMul } from "@setprotocol/index-coop-contracts/dist/utils/common";
 
 import {
@@ -24,14 +25,17 @@ const {
   USDC_ADDRESS,
 } = DEPENDENCY;
 
-export async function getUniswapV2Quote(tokenAddress: Address, targetPriceImpact: BigNumber): Promise<ExchangeQuote> {
-  const token: Token = await Fetcher.fetchTokenData(ChainId.MAINNET, tokenAddress);
-  const weth: Token = await Fetcher.fetchTokenData(ChainId.MAINNET, ETH_ADDRESS);
-  const wbtc: Token = await Fetcher.fetchTokenData(ChainId.MAINNET, BTC_ADDRESS);
-  const usdc: Token = await Fetcher.fetchTokenData(ChainId.MAINNET, USDC_ADDRESS);
+export async function getUniswapV2Quote(
+  provider: BaseProvider,
+  tokenAddress: Address,
+  targetPriceImpact: BigNumber): Promise<ExchangeQuote> {
+  const token: Token = await Fetcher.fetchTokenData(ChainId.MAINNET, tokenAddress, provider);
+  const weth: Token = await Fetcher.fetchTokenData(ChainId.MAINNET, ETH_ADDRESS, provider);
+  const wbtc: Token = await Fetcher.fetchTokenData(ChainId.MAINNET, BTC_ADDRESS, provider);
+  const usdc: Token = await Fetcher.fetchTokenData(ChainId.MAINNET, USDC_ADDRESS, provider);
 
   const trades = Trade.bestTradeExactIn(
-    await getUniswapV2Pairs([token, weth, wbtc, usdc]),
+    await getUniswapV2Pairs(provider, [token, weth, wbtc, usdc]),
     new TokenAmount(weth, ether(1).toString()),
     token,
     {maxNumResults: 3, maxHops: 2},
@@ -60,7 +64,7 @@ export async function getUniswapV2Quote(tokenAddress: Address, targetPriceImpact
   } as ExchangeQuote;
 }
 
-async function getUniswapV2Pairs(tokens: Token[]): Promise<Pair[]> {
+async function getUniswapV2Pairs(provider: BaseProvider, tokens: Token[]): Promise<Pair[]> {
   const pairs: Pair[] = [];
   for (let i = 0; i < tokens.length - 1; i++) {
     for (let j = 1; j < tokens.length - i - 1; j++) {
@@ -69,7 +73,7 @@ async function getUniswapV2Pairs(tokens: Token[]): Promise<Pair[]> {
 
       let pair;
       try {
-        pair = await Fetcher.fetchPairData(tokenOne, tokenTwo);
+        pair = await Fetcher.fetchPairData(tokenOne, tokenTwo, provider);
       } catch (error) {
         continue;
       }

--- a/tasks/rebalances/calculate-params.ts
+++ b/tasks/rebalances/calculate-params.ts
@@ -31,9 +31,9 @@ task("calculate-params", "Calculates new rebalance details for an index")
       console.log(assets[i]);
       const quotes: ExchangeQuote[] = [
         await getSushiswapQuote(deployHelper, info[assets[i]].address, FIFTY_BPS_IN_PERCENT),
-        await getUniswapV2Quote(info[assets[i]].address, FIFTY_BPS_IN_PERCENT),
+        await getUniswapV2Quote(hre.ethers.provider, info[assets[i]].address, FIFTY_BPS_IN_PERCENT),
         await getUniswapV3Quote(deployHelper, info[assets[i]].address, FORTY_BPS_IN_PERCENT),
-        await getKyberDMMQuote(info[assets[i]].address, FIFTY_BPS_IN_PERCENT),
+        await getKyberDMMQuote(hre.ethers.provider, info[assets[i]].address, FIFTY_BPS_IN_PERCENT),
         await getBalancerV1Quote(hre.ethers.provider, info[assets[i]].address, FIFTY_BPS_IN_PERCENT),
       ];
       console.log(quotes.reduce((p, c) => BigNumber.from(p.size).gt(BigNumber.from(c.size)) ? p : c));


### PR DESCRIPTION
Removes dependence on the `ethers.defaultProvider` in these methods. 

Seems like it might be throttled quite a bit in the admin UI. 

**API Resources**
+ [uniswap/sdk#fetchTokenData][1]
+ [dmm-sdk#fetchTokenData][2]

[1]: https://uniswap.org/docs/v2/SDK/fetcher/#fetchtokendata
[2]: https://docs.dmm.exchange/reference/SDK/fetcher#fetchtokendata

**Sanity Check**

Ran `params:calc:dpi` with these changes and got:

```
YFI
{
  exchange: 'SushiswapIndexExchangeAdapter',
  size: '13101409353721042129',
  data: '0x'
}
COMP
{
  exchange: 'UniswapV3IndexExchangeAdapter',
  size: '228379371078269991260',
  data: '0x000bb8'
}
SNX
{
  exchange: 'SushiswapIndexExchangeAdapter',
  size: '4054903860729552785311',
  data: '0x'
}
MKR
{
  exchange: 'UniswapV3IndexExchangeAdapter',
  size: '54198071283742407447',
  data: '0x000bb8'
}
REN
{
  exchange: 'SushiswapIndexExchangeAdapter',
  size: '61706146283410633419519',
  data: '0x'
}
KNC
Error Getting Token Price. Defaulting to 0.
{
  exchange: 'KyberV3IndexExchangeAdapter',
  size: '64661069770458239279757',
  data: '0x61639D6eC06C13a96B5eB9560b359D7c648C7759'
}
LRC
{
  exchange: 'UniswapV2IndexExchangeAdapter',
  size: '15707635368032119947441',
  data: '0x'
}
BAL
{
  exchange: 'BalancerV1IndexExchangeAdapter',
  size: '4742636112676001363250',
  data: '0x'
}
UNI
{
  exchange: 'UniswapV3IndexExchangeAdapter',
  size: '44812407960231759379982',
  data: '0x000bb8'
}
AAVE
{
  exchange: 'SushiswapIndexExchangeAdapter',
  size: '1004739328316078029568',
  data: '0x'
}
MTA
{
  exchange: 'UniswapV2IndexExchangeAdapter',
  size: '5585745465019020516211',
  data: '0x'
}
SUSHI
{
  exchange: 'SushiswapIndexExchangeAdapter',
  size: '102262238638855703860070',
  data: '0x'
}
CREAM
{
  exchange: 'BalancerV1IndexExchangeAdapter',
  size: '61444971778770539100',
  data: '0x'
}
FARM
{
  exchange: 'UniswapV2IndexExchangeAdapter',
  size: '179820714669293527824',
  data: '0x'
}
BADGER
{
  exchange: 'SushiswapIndexExchangeAdapter',
  size: '2654706898141414784131',
  data: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'
}
```