### PR TITLE
Coerce Kyber price impact calculation to 18 decimals.

### DIFF
--- a/index-rebalances/utils/paramDetermination/kyberDMM.ts
+++ b/index-rebalances/utils/paramDetermination/kyberDMM.ts
@@ -51,7 +51,7 @@ export async function getKyberDMMQuote(
     const priceImpactRatio = preciseDiv(
       targetPriceImpact,
       // Price impact measured in percent so fee must be as well
-      ether(parseFloat(trades[0].priceImpact.toSignificant(18)) - fee.toNumber() / 10 ** 16)
+      ether((parseFloat(trades[0].priceImpact.toSignificant(18)) - fee.toNumber() / 10 ** 16).toFixed(18))
     );
 
     return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/index-rebalance-utils",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Utilities for param and allocation determination for Set Protocol indices.",
   "main": "dist",
   "types": "dist/types",


### PR DESCRIPTION
```
3145643761554811 0.3145643761554811 0.316972766050552038 0.002408389895070917
3145643761554811 0.3145643761554811 0.316972766050552038 0.002408389895070917
3145643761554811 0.3145643761554811 0.316972766050552038 0.002408389895070917
3145643761554811 0.3145643761554811 0.316972766050552038 0.002408389895070917
3144381269710481 0.3144381269710481 0.316844929335920018 0.002406802364871896
3143115662630530 0.314311566263053 0.316717092621287997 0.0024055263582349884 <-- ERROR
```
Whenever the fee percentage (first/second column) had a trailing zero it would lead to calculating a value with 19 decimals (at this point unsure of reason). In order to fix, coerced calculation output to 18 decimals.