### PR TITLE
added sell size to uni v3 quote

### DIFF
--- a/index-rebalances/types.ts
+++ b/index-rebalances/types.ts
@@ -39,6 +39,7 @@ export interface Exchanges {
 export interface ExchangeQuote {
   exchange: string;
   size: string;
+  sellSize?: string;
   data: string;
 }
 

--- a/index-rebalances/utils/paramDetermination/uniswapV3.ts
+++ b/index-rebalances/utils/paramDetermination/uniswapV3.ts
@@ -59,13 +59,24 @@ export async function getUniswapV3Quote(deployHelper: DeployHelper, token: Addre
 
   return {
     exchange: exchanges.UNISWAP_V3,
-    size:   (await quoterInstance.callStatic.quoteExactInputSingle(
-      ETH_ADDRESS,
-      token,
-      FeeAmount.MEDIUM,
-      ether(10000),
-      sqrtPriceLimit
-    )).toString(),
+    size: (
+      await quoterInstance.callStatic.quoteExactInputSingle(
+        ETH_ADDRESS,
+        token,
+        FeeAmount.MEDIUM,
+        ether(10000),
+        sqrtPriceLimit
+      )
+    ).toString(),
+    sellSize: (
+      await quoterInstance.callStatic.quoteExactInputSingle(
+        token,
+        ETH_ADDRESS,
+        FeeAmount.MEDIUM,
+        ether(10000),
+        sqrtPriceLimit
+      )
+    ).toString(),
     data: hexZeroPad(hexlify(FeeAmount.MEDIUM), 3),
   } as ExchangeQuote;
 }


### PR DESCRIPTION
This change is adding the size functionality back with flipped token addresses, which should mimic sell size vs the original buy size