### PR TITLE
Use balancer.SOR.fetchPools (instead of fetchFilteredPairPools)

### DIFF
--- a/index-rebalances/utils/paramDetermination/balancerV1.ts
+++ b/index-rebalances/utils/paramDetermination/balancerV1.ts
@@ -25,7 +25,7 @@ export async function getBalancerV1Quote(provider: BaseProvider, tokenAddress: A
     1,      // ChainId = mainnet (1)
     "https://storageapi.fleek.co/balancer-bucket/balancer-exchange/pools"
   );
-  await sor.fetchFilteredPairPools(ETH_ADDRESS, tokenAddress);
+  await sor.fetchPools();
   await sor.setCostOutputToken(tokenAddress);   // Set cost to limit small trades
 
   const inputAmount = toBigNumberJS(ether(2));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/index-rebalance-utils",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Utilities for param and allocation determination for Set Protocol indices.",
   "main": "dist",
   "types": "dist/types",


### PR DESCRIPTION
We're seeing Balancer's `fetchFilteredPairPools` throw errors in the Gnosis Safe app:


![Screen Shot 2021-11-02 at 10 04 37 AM](https://user-images.githubusercontent.com/7332026/139959543-27a3d50c-06ba-4cec-8ced-a6def89bf421.png)

PR uses SOR.[fetchPools][1] instead, which seems to work without issue and was suggested by the Balancer team.

[1]: https://balancer.gitbook.io/balancer/smart-contracts/sor/development#await-sor-fetchpools