### PR TITLE
Support DPI flexible cap targets

### DIFF
--- a/index-rebalances/utils/rebalanceLib.ts
+++ b/index-rebalances/utils/rebalanceLib.ts
@@ -37,8 +37,9 @@ export function getRebalanceInputs(
   };
 }
 
-// DPI allocations are a function of token market cap. Some tokens (ex: uni) are "flexibly capped"
-// at 25% of the index even though their natural weight would be higher.
+// DPI allocations are a function of token market cap. Any token which would comprise more than 25%
+// of the total value in the Set is "flexibly capped" at 25% of the index even though their natural
+// weight would be higher
 export function calculateNewDPIAllocations(
   totalSupply: BigNumber,
   strategyConstants: StrategyObject,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/index-rebalance-utils",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Utilities for param and allocation determination for Set Protocol indices.",
   "main": "dist",
   "types": "dist/types",


### PR DESCRIPTION
@controtie wrote in slack that the DPI capped target allocation logic is being adjusted to use a flexible cap system: 

For reference, the methodology text:

> Any token that has a weight greater than 25% based on its market cap during the Determination Phase will have its weight capped. The target weight of the capped token will be the average of its current index weight and 25%.

PR implements this change. (Will post a screenshot of this logic working in the admin UI shortly)